### PR TITLE
Color gradient trace

### DIFF
--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -556,12 +556,14 @@ void Diagram::calcData(Graph *g) {
             for (i = g->countY; i > 0; i--) {  // every branch of curves
                 px = g->axis(0)->Points;
                 calcCoordinateP(px, pz, py, p, pa);
+                p->setIndep(*px);
                 ++px;
                 pz += 2;
                 ++p;
                 for (z = g->axis(0)->count - 1; z > 0; z--) {  // every point
                     FIT_MEMORY_SIZE;  // need to enlarge memory block ?
                     calcCoordinateP(px, pz, py, p, pa);
+                    p->setIndep(*px);
                     ++px;
                     pz += 2;
                     ++p;

--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -169,6 +169,7 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
   precisionSpin = 0;
   precisionLabel = 0;
   ColorButt = 0;
+  GradientCheck = 0;
   hideInvisible = 0;
   rotationX = rotationY = rotationZ = 0;
 
@@ -284,6 +285,18 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
       connect(yAxisBox, QOverload<int>::of(&QComboBox::activated), this,
               &DiagramDialog::slotSetYAxis);
     }
+
+    // Gradient
+    QWidget *Box2c = new QWidget();
+    QHBoxLayout *Box2cLayout = new QHBoxLayout();
+    Box2c->setLayout(Box2cLayout);
+    InputGroupLayout->addWidget(Box2c);
+    Box2cLayout->setSpacing(5);
+
+    GradientCheck = new QCheckBox(tr("Color by sweep value"));
+    Box2cLayout->addWidget(GradientCheck);
+    GradientCheck->setEnabled(false);
+    connect(GradientCheck, &QCheckBox::stateChanged, this, &DiagramDialog::slotToggleGradient);
   }
 
   if (thicknessSpin) {
@@ -1183,6 +1196,10 @@ void DiagramDialog::slotTakeVar(QTableWidgetItem *Item) {
     }
     Label3->setEnabled(true);
     ColorButt->setEnabled(true);
+
+    // Gradient
+    g->GradientEnabled = GradientCheck->isChecked();
+    GradientCheck->setEnabled(true);
   } else if (Diag->Name == "Tab") { // Changed from 'else' to 'else if'
     if (precisionSpin) {            // Add null check
       g->Precision = precisionSpin->value();
@@ -1273,6 +1290,12 @@ void DiagramDialog::SelectGraph(Graph *g) {
 
       Label3->setEnabled(true);
       ColorButt->setEnabled(true);
+
+      // Gradient
+      GradientCheck->blockSignals(true);
+      GradientCheck->setChecked(g->GradientEnabled);
+      GradientCheck->blockSignals(false);
+      GradientCheck->setEnabled(true);
     }
   } else {
     precisionSpin->setValue(g->Precision);
@@ -1344,6 +1367,13 @@ void DiagramDialog::slotDeleteGraph() {
     }
     Label3->setEnabled(false);
     ColorButt->setEnabled(false);
+
+    // Gradient
+    GradientCheck->blockSignals(true);
+    GradientCheck->setChecked(false);
+    GradientCheck->blockSignals(false);
+    GradientCheck->setEnabled(false);
+
   } else {
     if (precisionSpin)
       precisionSpin->setValue(3);
@@ -1406,6 +1436,8 @@ void DiagramDialog::slotNewGraph() {
     } else if (Diag->Name == "Rect3D") {
       g->yAxisNo = 1;
     }
+
+    g->GradientEnabled = GradientCheck->isChecked();
   } else {
     g->Precision = precisionSpin->value();
     g->numMode = PropertyBox->currentIndex();
@@ -2205,7 +2237,15 @@ void DiagramDialog::updateGraphListItem(int row) {
       colorItem->setFlags(colorItem->flags() ^ Qt::ItemIsEditable);
       GraphList->setItem(row, 1, colorItem);
     }
-    colorItem->setBackground(QBrush(g->Color));
+    if (g->GradientEnabled) {
+      QLinearGradient grad(0, 0, 1, 0);
+      grad.setCoordinateMode(QGradient::ObjectBoundingMode);
+      grad.setColorAt(0.0, QColor(0x0000ff));
+      grad.setColorAt(1.0, QColor(0xff0000));
+      colorItem->setBackground(QBrush(grad));
+    } else {
+      colorItem->setBackground(QBrush(g->Color));
+    }
 
     // Column 2: Style
     QString styleName;
@@ -2274,4 +2314,14 @@ void DiagramDialog::updateGraphListItem(int row) {
       axisItem->setText(axisName);
     }
   }
+}
+
+
+void DiagramDialog::slotToggleGradient(int state) {
+  bool on = (state == Qt::Checked);
+  int i = GraphList->currentRow();
+  if (i < 0) return;
+  Graphs.at(i)->GradientEnabled = on;
+  changed = true;
+  toTake = false;
 }

--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -2235,11 +2235,20 @@ void DiagramDialog::updateGraphListItem(int row) {
       GraphList->setItem(row, 1, colorItem);
     }
     if (g->GradientEnabled) {
-      QLinearGradient grad(0, 0, 1, 0);
-      grad.setCoordinateMode(QGradient::ObjectBoundingMode);
-      grad.setColorAt(0.0, QColor(0x0000ff));
-      grad.setColorAt(1.0, QColor(0xff0000));
-      colorItem->setBackground(QBrush(grad));
+      QPixmap swatch(48, 16);
+      swatch.fill(Qt::transparent);
+      QPainter swatchPainter(&swatch);
+      QLinearGradient grad(0, 0, swatch.width(), 0);
+      // Match interpolateColor() in graph.cpp: hue sweep 240° (blue) ->
+      // 0° (red), passing through cyan/green/yellow, not a flat RGB blend.
+      for (int i = 0; i <= 8; ++i) {
+        double t = i / 8.0;
+        int hue = static_cast<int>(std::lround(240.0 * (1.0 - t)));
+        grad.setColorAt(t, QColor::fromHsv(hue, 220, 220));
+      }
+      swatchPainter.fillRect(swatch.rect(), grad);
+      swatchPainter.end();
+      colorItem->setBackground(QBrush(swatch));
     } else {
       colorItem->setBackground(QBrush(g->Color));
     }
@@ -2319,9 +2328,18 @@ void DiagramDialog::updateGraphListItem(int row) {
 // (sweep-value) coloring is enabled for the graph.
 QString DiagramDialog::colorButtStyleSheet(bool gradientEnabled, const QColor& solid) const {
   if (gradientEnabled) {
+    // Match interpolateColor() in graph.cpp: hue sweep 240° (blue) ->
+    // 0° (red), passing through cyan/green/yellow, not a flat RGB blend.
+    QStringList stops;
+    for (int i = 0; i <= 8; ++i) {
+      double t = i / 8.0;
+      int hue = static_cast<int>(std::lround(240.0 * (1.0 - t)));
+      QColor c = QColor::fromHsv(hue, 220, 220);
+      stops << QStringLiteral("stop:%1 %2").arg(t).arg(c.name());
+    }
     return QStringLiteral(
-        "QPushButton {background-color: qlineargradient("
-        "x1:0, y1:0, x2:1, y2:0, stop:0 blue, stop:1 red);}");
+           "QPushButton {background-color: qlineargradient("
+           "x1:0, y1:0, x2:1, y2:0, %1);}").arg(stops.join(", "));
   }
   return QStringLiteral("QPushButton {background-color: %1};").arg(solid.name());
 }
@@ -2336,6 +2354,8 @@ void DiagramDialog::slotToggleGradient(int state) {
 
   ColorButt->setStyleSheet(colorButtStyleSheet(on, Graphs.at(i)->Color));
   ColorButt->setEnabled(!on);
+
+  updateGraphListItem(i);
 
   changed = true;
   toTake = false;

--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -227,14 +227,24 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
             &DiagramDialog::slotSetPrecision);
 
   } else if (Diag->Name != "Truth") {
-    Label1 = new QLabel(tr("Color:"));
-    Box2Layout->addWidget(Label1);
+
+    Label1 = new QLabel(tr("")); // No longer used for the color, but it may be reused by other plot types.
+
+    ColorGroupBox = new QGroupBox(tr("Color"));
+    QHBoxLayout *ColorGroupLayout = new QHBoxLayout();
+    ColorGroupBox->setLayout(ColorGroupLayout);
+    Box2Layout->addWidget(ColorGroupBox);
+
     ColorButt = new QPushButton("   ");
-    Box2Layout->addWidget(ColorButt);
+    ColorGroupLayout->addWidget(ColorButt);
     ColorButt->setMinimumWidth(50);
     ColorButt->setEnabled(false);
-    connect(ColorButt, &QPushButton::clicked, this,
-            &DiagramDialog::slotSetColor);
+    connect(ColorButt, &QPushButton::clicked, this, &DiagramDialog::slotSetColor);
+
+    GradientCheck = new QCheckBox(tr("Gradient"));
+    ColorGroupLayout->addWidget(GradientCheck);
+    GradientCheck->setEnabled(false);
+    connect(GradientCheck, &QCheckBox::stateChanged, this, &DiagramDialog::slotToggleGradient);
 
     Box2Layout->setStretchFactor(new QWidget(Box2),
                                  5); // stretchable placeholder
@@ -285,18 +295,6 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
       connect(yAxisBox, QOverload<int>::of(&QComboBox::activated), this,
               &DiagramDialog::slotSetYAxis);
     }
-
-    // Gradient
-    QWidget *Box2c = new QWidget();
-    QHBoxLayout *Box2cLayout = new QHBoxLayout();
-    Box2c->setLayout(Box2cLayout);
-    InputGroupLayout->addWidget(Box2c);
-    Box2cLayout->setSpacing(5);
-
-    GradientCheck = new QCheckBox(tr("Color by sweep value"));
-    Box2cLayout->addWidget(GradientCheck);
-    GradientCheck->setEnabled(false);
-    connect(GradientCheck, &QCheckBox::stateChanged, this, &DiagramDialog::slotToggleGradient);
   }
 
   if (thicknessSpin) {

--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -1176,9 +1176,7 @@ void DiagramDialog::slotTakeVar(QTableWidgetItem *Item) {
     g->Thick = thicknessSpin->value();
     QColor selectedColor(
         DefaultColors[GraphList->rowCount() % NumDefaultColors]);
-    QString stylesheet = QStringLiteral("QPushButton {background-color: %1};")
-                             .arg(selectedColor.name());
-    ColorButt->setStyleSheet(stylesheet);
+
     misc::setPickerColor(ColorButt, selectedColor);
     if (g->Var.right(3) == ".Vb")
       if (PropertyBox->count() >= GRAPHSTYLE_ARROW)
@@ -1193,11 +1191,13 @@ void DiagramDialog::slotTakeVar(QTableWidgetItem *Item) {
       g->yAxisNo = 1;
     }
     Label3->setEnabled(true);
-    ColorButt->setEnabled(true);
 
     // Gradient
     g->GradientEnabled = GradientCheck->isChecked();
+    ColorButt->setEnabled(!g->GradientEnabled);
     GradientCheck->setEnabled(true);
+    ColorButt->setStyleSheet(colorButtStyleSheet(g->GradientEnabled, selectedColor));
+    ColorButt->setEnabled(!g->GradientEnabled);
   } else if (Diag->Name == "Tab") { // Changed from 'else' to 'else if'
     if (precisionSpin) {            // Add null check
       g->Precision = precisionSpin->value();
@@ -1275,9 +1275,6 @@ void DiagramDialog::SelectGraph(Graph *g) {
   if (Diag->Name != "Tab") {
     if (Diag->Name != "Truth") {
       thicknessSpin->setValue(g->Thick);
-      QString stylesheet = QStringLiteral("QPushButton {background-color: %1};")
-                               .arg(g->Color.name());
-      ColorButt->setStyleSheet(stylesheet);
       misc::setPickerColor(ColorButt, g->Color);
       PropertyBox->setCurrentIndex(g->Style);
       if (yAxisBox) {
@@ -1285,15 +1282,17 @@ void DiagramDialog::SelectGraph(Graph *g) {
         yAxisBox->setEnabled(true);
         Label4->setEnabled(true);
       }
-
       Label3->setEnabled(true);
-      ColorButt->setEnabled(true);
 
       // Gradient
       GradientCheck->blockSignals(true);
       GradientCheck->setChecked(g->GradientEnabled);
       GradientCheck->blockSignals(false);
       GradientCheck->setEnabled(true);
+      ColorButt->setEnabled(!g->GradientEnabled);
+
+      ColorButt->setStyleSheet(colorButtStyleSheet(g->GradientEnabled, g->Color));
+      ColorButt->setEnabled(!g->GradientEnabled);
     }
   } else {
     precisionSpin->setValue(g->Precision);
@@ -2315,11 +2314,29 @@ void DiagramDialog::updateGraphListItem(int row) {
 }
 
 
+// Returns the stylesheet for the color-swatch button: either the plain
+// solid trace color, or a blue-to-red gradient preview when gradient
+// (sweep-value) coloring is enabled for the graph.
+QString DiagramDialog::colorButtStyleSheet(bool gradientEnabled, const QColor& solid) const {
+  if (gradientEnabled) {
+    return QStringLiteral(
+        "QPushButton {background-color: qlineargradient("
+        "x1:0, y1:0, x2:1, y2:0, stop:0 blue, stop:1 red);}");
+  }
+  return QStringLiteral("QPushButton {background-color: %1};").arg(solid.name());
+}
+
 void DiagramDialog::slotToggleGradient(int state) {
   bool on = (state == Qt::Checked);
+  ColorButt->setEnabled(!on);
+
   int i = GraphList->currentRow();
   if (i < 0) return;
   Graphs.at(i)->GradientEnabled = on;
+
+  ColorButt->setStyleSheet(colorButtStyleSheet(on, Graphs.at(i)->Color));
+  ColorButt->setEnabled(!on);
+
   changed = true;
   toTake = false;
 }

--- a/qucs/diagrams/diagramdialog.h
+++ b/qucs/diagrams/diagramdialog.h
@@ -25,6 +25,7 @@
 
 #include <QDialog>
 #include <QSpinBox>
+#include <QGroupBox>
 #include <QRegularExpression>
 #include <QRegularExpressionValidator>
 #include <vector>
@@ -173,6 +174,7 @@ private:
   QComboBox   *PropertyBox, *GridStyleBox, *yAxisBox, *NotationBox;
   QPushButton *ColorButt, *GridColorButt;
   QCheckBox   *GradientCheck;
+  QGroupBox   *ColorGroupBox;
   QSlider     *SliderRotX, *SliderRotY, *SliderRotZ;
   Cross3D     *DiagCross;
   bool changed, transfer, toTake;

--- a/qucs/diagrams/diagramdialog.h
+++ b/qucs/diagrams/diagramdialog.h
@@ -69,6 +69,7 @@ private slots:
   void slotCancel();
   void slotSetColor();
   void slotSetGridColor();
+  void slotToggleGradient(int);
   void slotResetToTake(const QString&);
   void slotSetNumMode(int);
   void slotSetGridBox(int);
@@ -128,7 +129,7 @@ private slots:
   void slotSetPrecision(int);
 
 protected slots:
-    void reject();
+    void reject() override;
 
 private:
   void SelectGraph(Graph*);
@@ -171,6 +172,7 @@ private:
   QLabel      *thicknessLabel, *precisionLabel;
   QComboBox   *PropertyBox, *GridStyleBox, *yAxisBox, *NotationBox;
   QPushButton *ColorButt, *GridColorButt;
+  QCheckBox   *GradientCheck;
   QSlider     *SliderRotX, *SliderRotY, *SliderRotZ;
   Cross3D     *DiagCross;
   bool changed, transfer, toTake;

--- a/qucs/diagrams/diagramdialog.h
+++ b/qucs/diagrams/diagramdialog.h
@@ -135,6 +135,7 @@ protected slots:
 private:
   void SelectGraph(Graph*);
   void updateXVar();
+  QString colorButtStyleSheet(bool gradientEnabled, const QColor& solid) const;
   ///
   /// \brief Updates the content of the graph list to see the trace name along with the trace properties
   /// \param row: Number of the row to update

--- a/qucs/diagrams/graph.cpp
+++ b/qucs/diagrams/graph.cpp
@@ -40,6 +40,11 @@ Graph::Graph(Diagram const* d, const QString& _Line) :
   countY = 0;    // no points in graph
   Thick  = numMode = 0;
   Color  = 0x0000ff;   // blue
+
+  /// Gradient settings initialization @{
+  GradientEnabled   = false;
+  /// @}
+
   Precision  = 3;
   isSelected = false;
   yAxisNo = 0;   // left y axis
@@ -99,7 +104,11 @@ void Graph::paintLines(QPainter* painter) {
       drawArrowSymbols(painter);
       break;
     default:
-      drawLines(painter);
+      if (GradientEnabled) {
+        drawGradientLines(painter);
+      } else {
+        drawLines(painter);
+      }
   }
 }
 
@@ -109,7 +118,9 @@ QString Graph::save()
   QString s = "\t<\""+Var+"\" "+Color.name()+
 	      " "+QString::number(Thick)+" "+QString::number(Precision)+
 	      " "+QString::number(numMode)+" "+QString::number(Style)+
-	      " "+QString::number(yAxisNo)+">";
+          " "+QString::number(yAxisNo)+
+          " "+QString::number(GradientEnabled?1:0)+
+          ">";
 
   for (Marker *pm : std::as_const(Markers))
     s += "\n\t  "+pm->save();
@@ -156,6 +167,13 @@ bool Graph::load(const QString& _s)
   if(n.isEmpty()) return true;   // backward compatible
   yAxisNo = n.toInt(&ok);
   if(!ok) return false;
+
+  n = s.section(' ',7,7);
+  if (n.isEmpty()) {
+    // old files: no gradient info
+    return true;
+  }
+  GradientEnabled = (n.toInt() != 0);
 
   return true;
 }
@@ -261,7 +279,7 @@ Graph* Graph::sameNewOne()
   pg->Color = Color;
   pg->Thick = Thick;
   pg->Style = Style;
-
+  pg->GradientEnabled   = GradientEnabled;
   pg->Precision = Precision;
   pg->numMode   = numMode;
   pg->yAxisNo   = yAxisNo;
@@ -628,4 +646,85 @@ void Graph::drawLines(QPainter* painter) const {
   painter->restore();
 }
 
-// vim:ts=8:sw=2:et
+/// @brief Maps a position to a color, sweeping from blue (low) to red (high)
+/// @param t Normalized position along the sweep [0, 1]
+/// @return Interpolated color
+static QColor interpolateColor(double t) {
+
+  // Ensure t is in range [0, 1]
+  t = std::clamp(t, 0.0, 1.0);
+
+  // Jet-style stops: blue, cyan, green, yellow, red
+  static const QColor stops[] = {
+      QColor(0,   0,   255),
+      QColor(0,   255, 255),
+      QColor(0,   255, 0),
+      QColor(255, 255, 0),
+      QColor(255, 0,   0),
+  };
+  constexpr int n = 5;
+
+  double scaled = t * (n - 1);
+  int    i0 = static_cast<int>(std::floor(scaled));
+  int    i1 = std::min(i0 + 1, n - 1);
+  double frac = scaled - i0;
+
+  const QColor& c0 = stops[i0];
+  const QColor& c1 = stops[i1];
+  return QColor(c0.red()   + frac * (c1.red()   - c0.red()),
+                c0.green() + frac * (c1.green() - c0.green()),
+                c0.blue()  + frac * (c1.blue()  - c0.blue()));
+}
+
+void Graph::drawGradientLines(QPainter* painter) const {
+  painter->save();
+
+  // Find the maximum and the minimum value of the independent variable
+  double fMin =  std::numeric_limits<double>::infinity();
+  double fMax = -std::numeric_limits<double>::infinity();
+  for (const auto& point : *this) {
+    if (!point.isPt()) continue;
+    fMin = std::min(fMin, point.getIndep());
+    fMax = std::max(fMax, point.getIndep());
+  }
+
+  // Guard against single point painting
+  double range = 1;
+  if (fMax > fMin){
+    range = fMax - fMin;
+  }
+
+
+  QPen pen = painter->pen();
+  pen.setJoinStyle(Qt::RoundJoin);
+  pen.setCapStyle(Qt::RoundCap);
+
+  bool drawing_started = false;
+  QPointF segStart; double segStartIndep = 0;
+
+  // Walk the points, drawing one segment at a time with different color, depending on its position
+  for (const auto& point : *this) {
+    if (point.isGraphEnd()) break;
+    if (point.isStrokeEnd()) { drawing_started = false; continue; }
+    if (!point.isPt()) continue;
+
+    if (!drawing_started) {
+      segStart = QPointF(point.getScrX(), point.getScrY());
+      segStartIndep = point.getIndep();
+      drawing_started = true;
+      continue;
+    }
+
+    QPointF segEnd(point.getScrX(), point.getScrY());
+    double  tMid = ((segStartIndep + point.getIndep()) * 0.5 - fMin) / range;
+
+    // Draw segment
+    pen.setColor(interpolateColor(tMid));
+    painter->setPen(pen);
+    painter->drawLine(segStart, segEnd);
+
+    segStart = segEnd;
+    segStartIndep = point.getIndep();
+  }
+  painter->restore();
+}

--- a/qucs/diagrams/graph.h
+++ b/qucs/diagrams/graph.h
@@ -159,7 +159,10 @@ public:
   QString Var;
   QColor  Color;
   int     Thick;
+
   graphstyle_t Style;
+  bool    GradientEnabled;     // Enable color gradient traces
+
   QList<Marker *> Markers;
 
   // for tabular diagram
@@ -169,6 +172,11 @@ public:
 private: // painting
   void drawStarSymbols(QPainter* painter) const;
   void drawLines(QPainter* painter) const;
+
+  /// @brief Draw color gradient traces
+  /// @details The color of the trace varies according to the independent variable.
+  /// The pen changes at each line connecting two points.
+  void drawGradientLines(QPainter* painter) const;
   void drawCircleSymbols(QPainter* painter) const;
   void drawArrowSymbols(QPainter* painter) const;
 public: // marker related


### PR DESCRIPTION
When working with Smith Charts and polar plots I find useful to display a trace using a color gradient, so that one can quickly identify high/low frequencies without placing markers.

This PR adds an option to color a trace depending on the independent variable, instead of using a plain color. Although it was intially targetted to polar and Smith Charts, this mode is available to all trace diagrams.

<img width="1188" height="722" alt="image" src="https://github.com/user-attachments/assets/2f433cbd-ae93-4b41-93a0-6b35ea9deef1" />

<img width="652" height="594" alt="image" src="https://github.com/user-attachments/assets/8e1771c6-38d9-4c80-b253-28e98182faaa" />

An extra field is added when saving a trace to a file. Backward compatibility is guaranteed
<img width="1137" height="435" alt="image" src="https://github.com/user-attachments/assets/b18eeb53-81f2-45aa-a3f1-bf6d83fad057" />

