### PR TITLE
Point qucsator_rf to andresmmera/qucsator_rf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "qucsator_rf"]
 	path = qucsator_rf
-	url = https://github.com/ra3xdh/qucsator_rf
+	url = https://github.com/andresmmera/qucsator_rf
 [submodule "rxcalc"]
 	path = rxcalc
 	url = https://github.com/arhiv6/rxcalc


### PR DESCRIPTION
Fixed issue https://github.com/ra3xdh/qucs_s/issues/1713 in andresmmera/qucsator_rf

Pulling qucsator_rf from andresmmera/qucsator_rf instead of ra3xdh/qucsator_rf to check if the Windows build is now fixed.
