### PR TITLE
ImagePainting component: Open file browser in current project

### DIFF
--- a/qucs/paintings/imagepainting.cpp
+++ b/qucs/paintings/imagepainting.cpp
@@ -5,7 +5,9 @@
 
 #include "imagepainting.h"
 #include "SVGGalleryDialog.h" // Image templates
+#include "main.h"
 #include "misc.h"
+#include "qucs.h"
 #include "schematic.h"
 
 
@@ -468,11 +470,18 @@ void ImagePainting::setImageFromClipboard() {
 
 void ImagePainting::onBrowseClicked() {
 
+  // Set the directory for the file browser.
+  // If a project is opened, open that folder, otherwise, use the Qucs-S workspace directory.
+  QString startDir = QucsSettings.qucsWorkspaceDir.absolutePath();
+  if (QucsMain && !QucsMain->ProjName.isEmpty()) {
+      startDir = QucsSettings.QucsWorkDir.absolutePath();
+  }
+
   QString filter = QObject::tr("Images (*.bmp *.gif *.jpg *.jpeg *.png *.svg)");
   QString path = QFileDialog::getOpenFileName(
       m_pathEdit->parentWidget(),
       QObject::tr("Select Image"),
-      QDir::homePath(),
+      startDir,
       filter
       );
 


### PR DESCRIPTION
### Motivation

When browsing for an image in the image component properties dialog, the file dialog defaults to the user's home directory. When working within a project, it is much more convenient to start browsing in the active project directory where project assets are typically located.

### Changes

- Check if an active project is open; if so, open the file dialog in the project directory (`QucsSettings.QucsWorkDir.absolutePath()`).
- Fall back to the Qucs-S workspace directory (`QucsSettings.qucsWorkspaceDir.absolutePath()`, e.g., `~/QucsWorkspace`) if no project is open.
